### PR TITLE
Add data descriptor header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
       "name": "Thomas Müller",
       "email": "thomas.mueller@tmit.eu",
       "role": "Contributor"
+    },{
+      "name": "Roeland Jago Douma",
+      "email": "roeland@famdouma.nl",
+      "role": "Contributor"
     }
   ],
   "repositories": [ {

--- a/src/ZipStreamer.php
+++ b/src/ZipStreamer.php
@@ -49,6 +49,7 @@ class ZipStreamer {
   const VERSION = "1.0";
 
   const ZIP_LOCAL_FILE_HEADER = 0x04034b50; // local file header signature
+  const ZIP_DATA_DESCRIPTOR_HEADER = 0x08074b50; //data descriptor header signature
   const ZIP_CENTRAL_FILE_HEADER = 0x02014b50; // central file header signature
   const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50; // end of central directory record
   const ZIP64_END_OF_CENTRAL_DIRECTORY = 0x06064b50; //zip64 end of central directory record
@@ -431,16 +432,17 @@ class ZipStreamer {
 
   private function addDataDescriptor($dataLength, $gzLength, $dataCRC32) {
     if ($this->zip64) {
-      $length = 20;
+      $length = 24;
       $packedGzLength = pack64le($gzLength);
       $packedDataLength = pack64le($dataLength);
     } else {
-      $length = 12;
+      $length = 16;
       $packedGzLength = pack32le($gzLength->getLoBytes());
       $packedDataLength = pack32le($dataLength->getLoBytes());
      }
 
     $this->write(''
+        . pack32le(self::ZIP_DATA_DESCRIPTOR_HEADER)  // data descriptor header signature    4 bytes (0x08074b50)
         . pack32le($dataCRC32)  // crc-32                          4 bytes
         . $packedGzLength       // compressed size                 4/8 bytes (depending on zip64 enabled)
         . $packedDataLength     // uncompressed size               4/8 bytes (depending on zip64 enabled)

--- a/test/integration/UnpackTest.php
+++ b/test/integration/UnpackTest.php
@@ -35,7 +35,7 @@ class UnpackTest extends PHPUnit_Framework_TestCase
         $fullOutput = implode("\n", $output);
         $this->assertEquals($output[1], '7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21', $fullOutput);
         $this->assertEquals(0, $return_var, $fullOutput);
-        $this->assertTrue(in_array('1 file, 939 bytes (1 KiB)', $output), $fullOutput);
+        $this->assertTrue(in_array('1 file, 943 bytes (1 KiB)', $output), $fullOutput);
     }
 
     public function testUnzip() {


### PR DESCRIPTION
Makes the zipstreamer generate zip files that can natively be opened on OSX

As specified in 4.3.9.3 and 4.3.9.4

4.3.9.3 Although not originally assigned a signature, the value
      0x08074b50 has commonly been adopted as a signature value
      for the data descriptor record.  Implementers should be
      aware that ZIP files may be encountered with or without this
      signature marking data descriptors and SHOULD account for
      either case when reading ZIP files to ensure compatibility.

4.3.9.4 When writing ZIP files, implementors SHOULD include the
      signature value marking the data descriptor record.  When
      the signature is used, the fields currently defined for
      the data descriptor record will immediately follow the
      signature.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>