### PR TITLE
Fix issues arising from moves to Lib subdirectory & docker

### DIFF
--- a/src/Lib/Count64_64.php
+++ b/src/Lib/Count64_64.php
@@ -29,7 +29,7 @@ class Count64_64 extends Count64Base {
   private $value;
 
   public function getHiBytes() {
-    return urShift($this->value, 32);
+    return \ZipStreamer\urShift($this->value, 32);
   }
 
   public function getLoBytes() {

--- a/test/Count64Test.php
+++ b/test/Count64Test.php
@@ -90,7 +90,7 @@ class TestPack extends \PHPUnit\Framework\TestCase
   */
   public function testCount64Construct($loBytes, $hiBytes, $value, $description) {
     $count64 = ZipStreamer\Count64::construct($value);
-    $this->assertInstanceOf('ZipStreamer\Count64Base', $count64, $description . ' (instanceof)');
+    $this->assertInstanceOf('ZipStreamer\Lib\Count64Base', $count64, $description . ' (instanceof)');
     $this->assertEquals($loBytes, $count64->getLoBytes(), $description . " (loBytes)");
     $this->assertEquals($hiBytes, $count64->getHiBytes(), $description . " (hiBytes)");
   }
@@ -119,7 +119,7 @@ class TestPack extends \PHPUnit\Framework\TestCase
   public function testCount64Set($loBytes, $hiBytes, $value, $description) {
     $count64 = ZipStreamer\Count64::construct();
     $count64->set($value);
-    $this->assertInstanceOf('ZipStreamer\Count64Base', $count64, $description . ' (instanceof)');
+    $this->assertInstanceOf('ZipStreamer\Lib\Count64Base', $count64, $description . ' (instanceof)');
     $this->assertEquals($loBytes, $count64->getLoBytes(), $description . " (loBytes)");
     $this->assertEquals($hiBytes, $count64->getHiBytes(), $description . " (hiBytes)");
   }

--- a/test/integration/UnpackTest.php
+++ b/test/integration/UnpackTest.php
@@ -12,6 +12,14 @@ class UnpackTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
+        // skip this test if there is no working docker instance available
+        try {
+            exec('docker info');
+        } finally {
+            $this->markTestSkipped('No functional docker daemon available.');
+        }
+
+
         // create a zip file in tmp folder
         $this->tmpfname = tempnam("/tmp", "FOO");
         $outstream = fopen($this->tmpfname, 'w');


### PR DESCRIPTION
Fixes the following issues related to the move to /Lib subdir:

1) Count64_64 was looking for urShift() in its own namespace \ZipStreamer\Lib\urShift() instead of \ZipStreamer\urShift(). I've changed the namespace, but since this function is only used by Count64_64, it might make sense to move the function to \Lib instead.

2) Count64 tests were looking for the Count64Base class in \ZipStreamer\Count64Base, but it has moved to \ZipStreamer\Lib\Count64Base

Additionally, phpunit tests will fail if the testing system doesn't have a running docker instance. Since this is a failure of the test rig, rather than the code, I've changed it so that these tests are skipped if docker is unavailable. The test for this is rather crude (it just tests if "docker info" works), but should be enough to give people running the tests enough info to proceed further if something goes wrong.