### PR TITLE
Check if _SERVER['HTTP_USER_AGENT'] exists

### DIFF
--- a/src/ZipStreamer.php
+++ b/src/ZipStreamer.php
@@ -156,7 +156,7 @@ class ZipStreamer {
         header('Connection: Keep-Alive');
         header('Content-Type: ' . $contentType);
         // Use UTF-8 filenames when not using Internet Explorer
-        if(strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') > 0) {
+        if(isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') > 0) {
           header('Content-Disposition: attachment; filename="' . rawurlencode($archiveName) . '"' );
         }  else  {
           header( 'Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($archiveName)


### PR DESCRIPTION
In PHP 8.0+ accessing a non-existing array key produces a warning. This checks if the `$_SERVER['HTTP_USER_AGENT']` exists before accessing it. 