### PR TITLE
Fix 32bit compatibility

### DIFF
--- a/src/Count64.php
+++ b/src/Count64.php
@@ -113,7 +113,7 @@ function unpack32le($data) {
  */
 function pack64le($data) {
   if (is_object($data)) {
-    if ("Count64_32" == get_class($data)) {
+    if (Count64_32::class == get_class($data)) {
       $value = $data->_getValue();
       $hiBytess = $value[0];
       $loBytess = $value[1];


### PR DESCRIPTION
Since https://github.com/DeepDiver1975/PHPZipStreamer/pull/4 the class Count64_32 is in a namespace.

Because of that, the comparison was not correct anymore.