### PR TITLE
Don't stop reading if fread returns an empty string

### DIFF
--- a/src/ZipStreamer.php
+++ b/src/ZipStreamer.php
@@ -356,7 +356,7 @@ class ZipStreamer {
       $compStream = DeflateStream::create($level);
     }
 
-    while (!feof($stream) && $data = fread($stream, self::STREAM_CHUNK_SIZE)) {
+    while (!feof($stream) && ($data = fread($stream, self::STREAM_CHUNK_SIZE)) !== false) {
       $dataLength->add(strlen($data));
       hash_update($hashCtx, $data);
       if (COMPR::DEFLATE === $compress) {


### PR DESCRIPTION
This fixes a premature loop termination on empty string read, which can happen when reading from network streams, leading to packing truncated files silently.

By explicitly checking against "false", the loop will terminate only if fread returns a failure.

Fixes #19 with a minimally invasive change.